### PR TITLE
Raise exception if no url for the family exists in GF Upstream repo doc.

### DIFF
--- a/Google Fonts/qa.py
+++ b/Google Fonts/qa.py
@@ -190,15 +190,18 @@ class TestFontInfo(TestGlyphsFiles):
             )
 
             copyright_search = re.search(family_copyright_pattern, font.copyright)
-            self.assertIsNotNone(
-                copyright_search,
-                'font.copyright is incorrect. It must contain or be:\n' + \
-                'Copyright %s The %s Project Authors (%s)' %(
-                    datetime.now().year,
-                    font.familyName,
-                    repo_git_url,
+            if repo_git_url:
+                self.assertIsNotNone(
+                    copyright_search,
+                    'font.copyright is incorrect. It must contain or be:\n' + \
+                    'Copyright %s The %s Project Authors (%s)' %(
+                        datetime.now().year,
+                        font.familyName,
+                        repo_git_url,
+                    )
                 )
-            )
+            else:
+                raise Exception('GF Upstream doc has no git url for family')
 
     def test_style_names(self):
         """Instance names must be in STYLE_NAMES"""


### PR DESCRIPTION
If the family is listed in http://tinyurl.com/kflp3k7 and it does not have a url, raise an exception