### PR TITLE
Style linking checks add

### DIFF
--- a/Google Fonts/qa.py
+++ b/Google Fonts/qa.py
@@ -295,6 +295,18 @@ class TestFontInfo(TestGlyphsFiles):
                      ' Value must be set to 400')
                 )
 
+    def test_italic_instances_have_isItalic_set(self):
+        for font in self.fonts:
+            instances = font.instances
+            for instance in instances:
+                if 'Italic' in instance.name:
+                    self.assertEqual(
+                        instance.isItalic,
+                        True,
+                        '%s instance does not have "Italic of" enabled' % (
+                            instance.name)
+                        )
+
 
 class TestMultipleGlyphsFileConsistency(unittest.TestCase):
     """Families are often split into multiple .glyphs files.

--- a/Google Fonts/qa.py
+++ b/Google Fonts/qa.py
@@ -307,6 +307,14 @@ class TestFontInfo(TestGlyphsFiles):
                             instance.name
                         )
                     )
+                else:
+                    self.assertEqual(
+                        instance.isItalic,
+                        False,
+                        '%s instance must not have "Italic of" enabled' % (
+                            instance.name
+                        )
+                    )
 
     def test_instances_have_isBold_set(self):
         """Only the Bold and Bold Italic instances should have

--- a/Google Fonts/qa.py
+++ b/Google Fonts/qa.py
@@ -334,6 +334,21 @@ class TestFontInfo(TestGlyphsFiles):
                             )
                         )
 
+    def test_stylelinking_is_consistent_for_all_non_italic_instances(self):
+        for font in self.fonts:
+            instances = font.instances
+            for instance in instances:
+                if 'Italic' not in instance.name:
+                    self.assertEqual(
+                        '',
+                        instance.linkStyle,
+                        ("%s instance must have no style linking."
+                         " Delete link to %s") % (
+                            instance.name,
+                            instance.linkStyle 
+                        )
+                    )
+
 
 class TestMultipleGlyphsFileConsistency(unittest.TestCase):
     """Families are often split into multiple .glyphs files.

--- a/Google Fonts/qa.py
+++ b/Google Fonts/qa.py
@@ -308,6 +308,29 @@ class TestFontInfo(TestGlyphsFiles):
                         )
                     )
 
+    def test_instances_have_isBold_set(self):
+        """Only the Bold and Bold Italic instances should have
+        this flag set"""
+        for font in self.fonts:
+            instances = font.instances
+            for instance in instances:
+                if instance.name == 'Bold' or instance.name == 'Bold Italic':
+                    self.assertEqual(
+                        instance.isBold,
+                        True,
+                        '%s instance does not have "Bold of" enabled' % (
+                            instance.name
+                        )
+                    )
+                else:
+                    self.assertEqual(
+                        instance.isBold,
+                        False,
+                        '%s instance must not have "Bold of" enabled' %(
+                            instance.name
+                        )
+                    )
+
     def test_stylelinking_is_consistent_for_all_italic_instances(self):
         for font in self.fonts:
             instances = font.instances

--- a/Google Fonts/qa.py
+++ b/Google Fonts/qa.py
@@ -304,7 +304,34 @@ class TestFontInfo(TestGlyphsFiles):
                         instance.isItalic,
                         True,
                         '%s instance does not have "Italic of" enabled' % (
-                            instance.name)
+                            instance.name
+                        )
+                    )
+
+    def test_stylelinking_is_consistent_for_all_italic_instances(self):
+        for font in self.fonts:
+            instances = font.instances
+            for instance in instances:
+                if 'Italic' in instance.name:
+                    if instance.name == 'Italic' or instance.name == 'Bold Italic':
+                        self.assertEqual(
+                            '',
+                            instance.linkStyle,
+                            ("%s instance must have no style linking."
+                             " Delete link to %s") % (
+                                instance.name,
+                                instance.linkStyle
+                            )
+                        )
+                    else:
+                        roman_link_style = instance.name.split()[0]
+                        self.assertEqual(
+                            roman_link_style,
+                            instance.linkStyle,
+                            "%s instance must be style linked to %s" % (
+                                instance.name,
+                                roman_link_style
+                            )
                         )
 
 


### PR DESCRIPTION
Check to see whether instances have 'Italic of', 'is Bold' and 'linkStyle' flags correctly set.

Setting these flags correctly will make sure the generated fonts have the correct macStyle, fsSelection set.