### PR TITLE
New Test runner which is designer friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+*.pyc
 .DS_Store

--- a/Google Fonts/qa.py
+++ b/Google Fonts/qa.py
@@ -670,7 +670,7 @@ class TestVerticalMetrics(TestGlyphsFiles):
 
 
     def test_win_ascent_and_win_descent_equal_bbox(self):
-        """Check Win Ascent and Win Descent equal yMax, yMin of font bbox
+        """Check Win Ascent and Win Descent equal yMax, yMin of bbox
 
         MS recommends OS/2's win Ascent and win Descent must be the ymax
         and ymin of the bbox"""
@@ -690,9 +690,7 @@ class TestVerticalMetrics(TestGlyphsFiles):
                 self.assertEqual(
                     int(win_ascent),
                     ymax,
-                    ("Win Ascent does not equal yMax of font bounding "
-                     "box.\n\n"
-                     "%s master's winAscent %s is not equal to yMax %s") % (
+                    ("%s master's winAscent %s is not equal to yMax %s") % (
                         master.name,
                         win_ascent,
                         ymax)
@@ -701,9 +699,7 @@ class TestVerticalMetrics(TestGlyphsFiles):
                 self.assertEqual(
                     int(win_descent),
                     abs(ymin),
-                    ("Win Descent does not equal yMin of font bounding "
-                     "box.\n\n"
-                     "%s master's winDescent %s is not equal to yMin %s") % (
+                    ("%s master's winDescent %s is not equal to yMin %s") % (
                         master.name,
                         win_descent,
                         abs(ymin))

--- a/Google Fonts/qa.py
+++ b/Google Fonts/qa.py
@@ -6,6 +6,7 @@ https://github.com/googlefonts/gf-docs/blob/master/ProjectChecklist.md
 """
 import unittest
 from unittest import TestProgram
+from runner import GlyphsTestRunner
 import os
 from ntpath import basename
 import urllib
@@ -191,7 +192,7 @@ class TestGlyphsFiles(unittest.TestCase):
 class TestFontInfo(TestGlyphsFiles):
 
     def test_copyright(self):
-        """Copyright string matches specification:
+        """Check copyright string is correct
 
         https://github.com/googlefonts/gf-docs/blob/master/ProjectChecklist.md#ofltxt
 
@@ -232,7 +233,7 @@ class TestFontInfo(TestGlyphsFiles):
                 raise Exception('GF Upstream doc has no git url for family')
 
     def test_style_names(self):
-        """Instance names must conform to the Google Fonts API"""
+        """Check instances have the correct name for the GF API"""
         for font in self.fonts:
             instances = font.instances
             family_styles = set([i.name for i in instances])
@@ -245,6 +246,7 @@ class TestFontInfo(TestGlyphsFiles):
                      "%s") % (style, '\n- '.join(STYLE_NAMES)))
 
     def test_license_url(self):
+        """Check family has 'licenseURL' custom parameter"""
         for font in self.fonts:
             self.assertEqual(
                 font.customParameters['licenseURL'],
@@ -254,6 +256,7 @@ class TestFontInfo(TestGlyphsFiles):
             )
 
     def test_license(self):
+        """Check family has 'license' custom parameter"""
         for font in self.fonts:
             self.assertEqual(
                 font.customParameters['license'],
@@ -263,6 +266,7 @@ class TestFontInfo(TestGlyphsFiles):
             )
 
     def test_instance_weight_class(self):
+        """Check each instance has the correct weight value"""
         for font in self.fonts:
             instances = font.instances
             for instance in instances:
@@ -280,7 +284,9 @@ class TestFontInfo(TestGlyphsFiles):
                     print '%s is not a correct style name' % instance.name
 
     def test_single_instance_family_is_regular(self):
-        """If the font only has one instance, make sure its stylename and
+        """Check single weight families have Regular style name
+
+        If the font only has one instance, make sure its stylename and
         weight value is set to Regular, 400.
 
         Some MS application struggle when a family does not include a
@@ -301,6 +307,7 @@ class TestFontInfo(TestGlyphsFiles):
                 )
 
     def test_italic_instances_have_isItalic_set(self):
+        """Check only italic instances have 'isItalic' set"""
         for font in self.fonts:
             instances = font.instances
             for instance in instances:
@@ -324,8 +331,7 @@ class TestFontInfo(TestGlyphsFiles):
                     )
 
     def test_instances_have_isBold_set(self):
-        """Only the Bold and Bold Italic instances should have
-        this flag set"""
+        """Check only Bold and Bold Italic have 'isBold' set"""
         for font in self.fonts:
             instances = font.instances
             for instance in instances:
@@ -351,6 +357,7 @@ class TestFontInfo(TestGlyphsFiles):
                     )
 
     def test_stylelinking_is_consistent_for_all_italic_instances(self):
+        """Check style linking is correct for italic instances"""
         for font in self.fonts:
             instances = font.instances
             for instance in instances:
@@ -377,6 +384,7 @@ class TestFontInfo(TestGlyphsFiles):
                         )
 
     def test_stylelinking_is_consistent_for_all_non_italic_instances(self):
+        """Check style linking is correct for non italic instances"""
         for font in self.fonts:
             instances = font.instances
             for instance in instances:
@@ -400,6 +408,7 @@ class TestMultipleGlyphsFileConsistency(unittest.TestCase):
         self.fonts = Glyphs.fonts
 
     def test_files_share_same_attributes(self):
+        """Check all .glyph files share same parameters"""
         for font1 in self.fonts:
             for font2 in self.fonts:
                 for attrib in FONT_ATTRIBS:
@@ -418,6 +427,7 @@ class TestMultipleGlyphsFileConsistency(unittest.TestCase):
                     )
 
     def test_font_customParameters_are_equal(self):
+        """Check all .glyph files share same custom parameters"""
         for font1 in self.fonts:
             for font2 in self.fonts:
                 for param in font1.customParameters:
@@ -454,8 +464,7 @@ class TestRegressions(TestGlyphsFiles):
 
 
     def test_missing_glyphs(self):
-        """Family updates should include the same glyphs as the
-        previous release."""
+        """Check family includes all the glyphs in GF version"""
         if self.remote_font:
             local_fonts = self._hash_fonts(self.ttfs)
             remote_fonts = self._hash_fonts(self.remote_font)
@@ -476,8 +485,7 @@ class TestRegressions(TestGlyphsFiles):
                 )
 
     def test_missing_instances(self):
-        """Family updates must include the same instances as the previous
-        release."""
+        """Check family includes the same styles as GF version"""
         if self.remote_font:
             local_styles = self._get_font_styles(self.ttfs)
             remote_styles = self._get_font_styles(self.remote_font)
@@ -486,7 +494,9 @@ class TestRegressions(TestGlyphsFiles):
                             'Font is missing instances [%s] are all .glyphs file open?' % ', '.join(missing))
 
     def test_version_number_has_advanced(self):
-        """If the family has a version number lower than the family being
+        """Check family version number is greater than GF version
+
+        If the family has a version number lower than the family being
         served on fonts.google.com, it may mean the repository is based on
         older sources. Authors need to investigate if they are working from
         the correct source.
@@ -505,7 +515,9 @@ class TestRegressions(TestGlyphsFiles):
                 )
 
     def test_vert_metrics_visually_match(self):
-        """Vertical metrics must visually match the version hosted
+        """Test vertical metrics visually match GF version
+
+        Vertical metrics must visually match the version hosted
         on fonts.google.com.
 
         If the hosted family doesn't have the fsSelection bit 7 enabled,
@@ -623,19 +635,19 @@ class TestRegressions(TestGlyphsFiles):
 class TestVerticalMetrics(TestGlyphsFiles):
     
     def test_family_has_use_typo_metrics_enabled(self):
+        """Check family has 'Use Typo Metrics enabled'"""
         for font in self.fonts:
             self.assertEqual(
                 font.customParameters['Use Typo Metrics'],
                 True,
-                ("Font must have custom parameter 'Use Typo Metrics'"
+                ("Font must have custom parameter 'Use Typo Metrics' "
                  "enabled.\n\n"
                  "Add the custom parameter font.customParameters"
                  "['Use Typo Metrics'].")
             )
 
     def test_family_share_same_metric_values(self):
-        """If the family has not been released on Google Fonts, each
-        instance should have the same vertical metric values."""
+        """Check each instance has same vertical metric values"""
         if not self.remote_font:
             font_master1_params = self.fonts[0].masters[0].customParameters
 
@@ -658,7 +670,9 @@ class TestVerticalMetrics(TestGlyphsFiles):
 
 
     def test_win_ascent_and_win_descent_equal_bbox(self):
-        """MS recommends OS/2's win Ascent and win Descent must be the ymax
+        """Check Win Ascent and Win Descent equal yMax, yMin of font bbox
+
+        MS recommends OS/2's win Ascent and win Descent must be the ymax
         and ymin of the bbox"""
         family_ymax_ymin = []
         for font in self.fonts:
@@ -678,7 +692,7 @@ class TestVerticalMetrics(TestGlyphsFiles):
                     ymax,
                     ("Win Ascent does not equal yMax of font bounding "
                      "box.\n\n"
-                     "%s master's winAscent %s is not equal to %s") % (
+                     "%s master's winAscent %s is not equal to yMax %s") % (
                         master.name,
                         win_ascent,
                         ymax)
@@ -689,7 +703,7 @@ class TestVerticalMetrics(TestGlyphsFiles):
                     abs(ymin),
                     ("Win Descent does not equal yMin of font bounding "
                      "box.\n\n"
-                     "%s master's winDescent %s is not equal to %s") % (
+                     "%s master's winDescent %s is not equal to yMin %s") % (
                         master.name,
                         win_descent,
                         abs(ymin))
@@ -716,8 +730,7 @@ class TestRepositoryStructure(TestGlyphsFiles):
 
     """
     def test_repo_in_gf_upstream_repos_doc(self):
-        """Check the repository has been recorded in the GF Upstream doc,
-        http://tinyurl.com/kd9lort"""
+        """Check the family is in GF Upstream document"""
         found = False
         for font in self.fonts:
             for row in self.repos_doc:
@@ -732,6 +745,7 @@ class TestRepositoryStructure(TestGlyphsFiles):
             )
 
     def test_fonts_dir_exists(self):
+        """Check 'fonts' directory exists"""
         abs_fonts_folder = os.path.join(project_dir, FONTS_FOLDER)
         self.assertEquals(
             True,
@@ -744,6 +758,7 @@ class TestRepositoryStructure(TestGlyphsFiles):
         )
 
     def test_sources_dir_exists(self):
+        """Check 'sources' directory exists"""
         abs_sources_folder = os.path.join(project_dir, SOURCES_FOLDER)
         self.assertEquals(
             True,
@@ -757,6 +772,7 @@ class TestRepositoryStructure(TestGlyphsFiles):
         )
 
     def test_contributors_file_exists(self):
+        """Check 'CONTRIBUTORS.txt' exists"""
         self.assertIn(
             'CONTRIBUTORS.txt',
             os.listdir(project_dir),
@@ -766,6 +782,7 @@ class TestRepositoryStructure(TestGlyphsFiles):
         )
 
     def test_authors_file_exists(self):
+        """Check 'AUTHORS.txt' exists"""
         self.assertIn(
             'AUTHORS.txt',
             os.listdir(project_dir),
@@ -782,6 +799,6 @@ if __name__ == '__main__':
         os.path.join(os.path.dirname(__glyphsfile), '..')
     )
     if len(set([f.familyName for f in Glyphs.fonts])) == 1:
-        TestProgram(argv=['--verbose'], exit=False)
+        TestProgram(argv=['--verbose'], testRunner=GlyphsTestRunner, exit=False)
     else:
         print 'Test one family at a time'

--- a/Google Fonts/result.py
+++ b/Google Fonts/result.py
@@ -1,0 +1,40 @@
+from unittest import TestResult
+
+
+class GlyphsTestResult(TestResult):
+    """Customised Test Results which are readable to type designers"""
+    def addFailure(self, test, err):
+        """Called when an error has occurred. 'err' is a tuple of values as
+        returned by sys.exc_info()."""
+        # print(dir(test), test.shortDescription())
+        title = test.shortDescription()
+        self.failures.append((title, (self._exc_info_to_string(err, test))))
+        self._mirrorOutput = True
+
+    def _exc_info_to_string(self, err, test):
+        """Converts a sys.exc_info()-style tuple of values into a string."""
+        exctype, value, tb = err
+        # Skip test runner traceback levels
+        while tb and self._is_relevant_tb_level(tb):
+            tb = tb.tb_next
+
+        if exctype is test.failureException:
+            # Skip assert*() traceback levels
+            length = self._count_relevant_tb_levels(tb)
+            msgLines = value
+        else:
+            msgLines = value
+
+        if self.buffer:
+            output = sys.stdout.getvalue()
+            error = sys.stderr.getvalue()
+            print error
+            if output:
+                if not output.endswith('\n'):
+                    output += '\n'
+                msgLines.append(STDOUT_LINE % output)
+            if error:
+                if not error.endswith('\n'):
+                    error += '\n'
+                msgLines.append(STDERR_LINE % error)
+        return ''.join(msgLines)

--- a/Google Fonts/runner.py
+++ b/Google Fonts/runner.py
@@ -8,7 +8,7 @@ class GlyphsTestRunner(TextTestRunner):
     description = """Google Fonts QA
 ~~~~~~~~~~~~~~~
 
-Tests to ensure .glyphs file follow the Google Fonts specification.
+Tests to ensure .glyphs files follow the Google Fonts specification.
 
 The Google Fonts specification:
 https://github.com/googlefonts/gf-docs/blob/master/ProjectChecklist.md

--- a/Google Fonts/runner.py
+++ b/Google Fonts/runner.py
@@ -31,14 +31,17 @@ Google Fonts > Fix fonts for GF spec
         result.printErrors()
         run = result.testsRun
         self.stream.writeln(self.description)
-        self.stream.writeln("TESTS RUN: %s | PASSED: %s | FAILED: %s\n" % (
+        self.stream.writeln('=' * 80)
+        self.stream.writeln("TESTS RUN: %s | PASSED: %s | FAILED: %s" % (
             all_tests,
             passed_tests,
             failed_tests
             )
         )
+        self.stream.writeln('=' * 80)
+        self.stream.writeln('\n')
         
-        if not result.wasSuccessful():
+        if passed_tests != all_tests:
             for failed_test in result.failures:
                 title, fix_text = failed_test
                 self.stream.writeln('=' * 80)
@@ -47,6 +50,6 @@ Google Fonts > Fix fonts for GF spec
                 self.stream.writeln(''.join(fix_text))
                 self.stream.writeln('\n')
         else:
-            self.stream.writeln('PASSED. No Errors')
+            self.stream.writeln('All checks passed!')
 
         return result

--- a/Google Fonts/runner.py
+++ b/Google Fonts/runner.py
@@ -1,0 +1,52 @@
+from unittest import TextTestRunner
+from result import GlyphsTestResult
+
+
+class GlyphsTestRunner(TextTestRunner):
+    """Simple test runner which is suitable for type designers"""
+
+    description = """Google Fonts QA
+~~~~~~~~~~~~~~~
+
+Tests to ensure .glyphs file follow the Google Fonts specification.
+
+The Google Fonts specification:
+https://github.com/googlefonts/gf-docs/blob/master/ProjectChecklist.md
+
+Quick start guide for Glyphs:
+https://github.com/googlefonts/gf-docs/blob/master/QuickStartGlyphs.md
+
+
+A fix script which will attempt to update the font to match the
+specification can be found in the same directory as this script.
+Google Fonts > Fix fonts for GF spec
+
+    """
+    def run(self, test):
+        result = GlyphsTestResult()
+        test(result)
+        all_tests = result.testsRun
+        failed_tests = len(result.failures)
+        passed_tests = all_tests - failed_tests
+        result.printErrors()
+        run = result.testsRun
+        self.stream.writeln(self.description)
+        self.stream.writeln("TESTS RUN: %s | PASSED: %s | FAILED: %s\n" % (
+            all_tests,
+            passed_tests,
+            failed_tests
+            )
+        )
+        
+        if not result.wasSuccessful():
+            for failed_test in result.failures:
+                title, fix_text = failed_test
+                self.stream.writeln('=' * 80)
+                self.stream.writeln('FAIL: ' + title)
+                self.stream.writeln('-' * 80)
+                self.stream.writeln(''.join(fix_text))
+                self.stream.writeln('\n')
+        else:
+            self.stream.writeln('PASSED. No Errors')
+
+        return result


### PR DESCRIPTION
I've been going through @Gue3bara's updates and have decided to make the logging of my tools more designer friendly.

I've written our own runner for the unittest module which is designer friendly. Instructions to relevant documentation are also included.

![screen shot 2017-08-02 at 17 57 55](https://user-images.githubusercontent.com/7525512/28885061-4d4dba98-77ac-11e7-8346-6d2c2d2b4cad.png)

It previously looked like this:
![screen shot 2017-08-02 at 18 00 41](https://user-images.githubusercontent.com/7525512/28885115-86c04ea8-77ac-11e7-8ea6-2f0d90c43daf.png)

the previous version included python tracebacks and gave function names. I thought this could be intimidating to designers.

Tomorrow I will update the fix script for even more auto goodness. The workflow is rather simple, run fix script, then QA script.

cc @davelab6 