### PR TITLE
Fixed report generation bug.

### DIFF
--- a/Google Fonts/result.py
+++ b/Google Fonts/result.py
@@ -37,4 +37,4 @@ class GlyphsTestResult(TestResult):
                 if not error.endswith('\n'):
                     error += '\n'
                 msgLines.append(STDERR_LINE % error)
-        return ''.join(msgLines)
+        return ''.join(map(str, msgLines))


### PR DESCRIPTION
The msgLines list often contains integers. The string method ''.join(list) can only produce a string if every item in the list is a string.