### PR TITLE
Small changes to style name generation and vert metrics

### DIFF
--- a/Google Fonts/fixfonts.py
+++ b/Google Fonts/fixfonts.py
@@ -9,7 +9,8 @@ from utils import (
     ttf_family_style_name,
     RepoDoc,
     UPSTREAM_REPO_DOC,
-    norm_m
+    norm_m,
+    convert_camelcase
 )
 from datetime import datetime
 from vertmetrics import shortest_tallest_glyphs
@@ -210,23 +211,31 @@ def main():
 
     # fix instance names to pass gf spec
     for i, instance in enumerate(instances):
+        if 'Oblique' in instance.name:
+            instance.name = instance.name.replace('Oblique', 'Italic')
         if 'Italic' in instance.name:
             instance.isItalic = True
+            instance.name = instance.weight + ' Italic'
             if instance.weight != 'Bold' and instance.weight != 'Regular':
                 instance.linkStyle = instance.weight
             else:
                 instance.linkStyle = ''
         else:
+            instance.name = instance.weight
             instance.linkStyle = ''
 
-        # Seperate non Reg/Medium weights into their own family
+        # Seperate non Reg/Medium widths into their own family
         if instance.width != 'Medium (normal)':
             if instance.width == 'Semi Expanded':
                 family_suffix = instance.width
             else:
-                family_suffix = _convert_camelcase(instance.width)
+                family_suffix = convert_camelcase(instance.width)
             sub_family_name = '%s %s' % (font.familyName, family_suffix)
             instance.customParameters['familyName'] = sub_family_name
+            if 'Italic' in instance.name:
+                instance.name = instance.weight + ' Italic'
+            else:
+                instance.name = instance.weight
 
         if instance.weight == 'Bold':
             instance.isBold = True
@@ -248,7 +257,8 @@ def main():
 
     # Regressions fixing
     ttfs_gf = download_gf_family(font.familyName)
-    visual_inherit_vertical_metrics(font, ttfs_gf)
+    if ttfs_gf:
+        visual_inherit_vertical_metrics(font, ttfs_gf)
     set_win_asc_win_desc_to_bbox(font)
 
     # txt file generation

--- a/Google Fonts/qa.py
+++ b/Google Fonts/qa.py
@@ -270,7 +270,7 @@ class TestFontInfo(TestGlyphsFiles):
         from this rule."""
         for font in self.fonts:
             instances = font.instances
-            if len(instances) == 1:
+            if len(instances) == 1 and self.fonts < 2:
                 instance = instances[0]
                 self.assertEqual(
                     instance.name,

--- a/Google Fonts/qa.py
+++ b/Google Fonts/qa.py
@@ -20,13 +20,7 @@ import tempfile
 from math import ceil
 
 from vertmetrics import VERT_KEYS, shortest_tallest_glyphs
-from utils import (
-    download_gf_family,
-    UPSTREAM_REPO_URLS,
-    UPSTREAM_REPO_DOC,
-    RepoDoc,
-    norm_m
-)
+from utils import *
 
 FONT_ATTRIBS = [
     'familyName',

--- a/Google Fonts/result.py
+++ b/Google Fonts/result.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from unittest import TestResult
 
 
@@ -37,4 +38,4 @@ class GlyphsTestResult(TestResult):
                 if not error.endswith('\n'):
                     error += '\n'
                 msgLines.append(STDERR_LINE % error)
-        return ''.join(map(str, msgLines))
+        return ''.join(map(str, msgLines)).encode('utf-8')

--- a/Google Fonts/utils.py
+++ b/Google Fonts/utils.py
@@ -16,7 +16,7 @@ def ttf_family_style_name(ttfont):
         ps_name = ps_name.split('-')
     except: # else use win ps name
         ps_name = ttfont['name'].getName(6, 3, 1, 1033).string
-        ps_name = psn_name.decode('utf_16_be').split('-')
+        ps_name = ps_name.decode('utf_16_be').split('-')
     try:
         family, style = ps_name
         return family, style

--- a/Google Fonts/utils.py
+++ b/Google Fonts/utils.py
@@ -4,6 +4,8 @@ from zipfile import ZipFile
 from urllib import urlopen
 import csv
 from math import ceil
+import re
+
 
 API_URL_PREFIX = 'https://fonts.google.com/download?family='
 UPSTREAM_REPO_DOC = 'http://tinyurl.com/kflp3k7'


### PR DESCRIPTION
Since our api doesn't allow Oblique style names, the fixfonts script will rename Oblique to Italic e.g

Bold Oblique --> BoldItalic
Oblique --> Italic

---
Inherit vertical metrics will only be run if the fonts already exist on Google Fonts

---
utils.py fixed typo in variable name