### PR TITLE
Don't attempt to inherit vertical metrics if the family is not hosted on GF

### DIFF
--- a/Google Fonts/fixfonts.py
+++ b/Google Fonts/fixfonts.py
@@ -248,7 +248,8 @@ def main():
 
     # Regressions fixing
     ttfs_gf = download_gf_family(font.familyName)
-    visual_inherit_vertical_metrics(font, ttfs_gf)
+    if ttfs_gf:
+        visual_inherit_vertical_metrics(font, ttfs_gf)
     set_win_asc_win_desc_to_bbox(font)
 
     # txt file generation

--- a/Google Fonts/utils.py
+++ b/Google Fonts/utils.py
@@ -64,6 +64,7 @@ def download_gf_family(name):
     if remote_fonts:
         family_zip = ZipFile(StringIO(remote_fonts.read()))
         return fonts_from_zip(family_zip)
+    return None
 
 
 class RepoDoc:


### PR DESCRIPTION
Previously, the fix script would attempt to inherit a families vertical metrics, even if it wasn't hosted on GF. This caused the script to error.

Related to #30 