### PR TITLE
QA: Update checks to pass ArchivoBlack

### DIFF
--- a/Google Fonts/qa.py
+++ b/Google Fonts/qa.py
@@ -691,18 +691,16 @@ class TestVerticalMetrics(TestGlyphsFiles):
             for master in font.masters:
                 win_ascent = master.customParameters['winAscent']
                 win_descent = master.customParameters['winDescent']
-                self.assertEqual(
-                    int(win_ascent),
-                    ymax,
+                self.assertTrue(
+                    int(win_ascent) >= ymax,
                     ("%s master's winAscent %s is not equal to yMax %s") % (
                         master.name,
                         win_ascent,
                         ymax)
                 )
                 # ymin is abs because win descent is a positive integer
-                self.assertEqual(
-                    int(win_descent),
-                    abs(ymin),
+                self.assertTrue(
+                    int(win_descent) >= abs(ymin),
                     ("%s master's winDescent %s is not equal to yMin %s") % (
                         master.name,
                         win_descent,

--- a/Google Fonts/qa.py
+++ b/Google Fonts/qa.py
@@ -268,17 +268,19 @@ class TestFontInfo(TestGlyphsFiles):
 
         Single weight families which visually look heavy are not exempt
         from this rule."""
+        styles = []
         for font in self.fonts:
-            instances = font.instances
-            if len(instances) == 1:
-                instance = instances[0]
-                self.assertEqual(
-                    instance.name,
-                    'Regular',
-                    ("'%s' instance name is incorrect.\n\n"
-                     "Families which have just one instance must "
-                     "name the single 'Regular'") % instance.name
-                )
+            for instance in font.instances:
+                styles.append(instance.name)
+
+        if len(styles) == 1:
+            self.assertEqual(
+                styles[0],
+                'Regular',
+                ("'%s' instance name is incorrect.\n\n"
+                 "Families which have just one instance must "
+                 "name the instance 'Regular'") % styles[0]
+            )
 
     def test_italic_instances_have_isItalic_set(self):
         """Check only italic instances have 'isItalic' set"""


### PR DESCRIPTION
Whilst QAing Archivo Black, https://github.com/Omnibus-Type/ArchivoBlack, I came across the following two false positives.

```
================================================================================
FAIL: Check single weight families have Regular style name
--------------------------------------------------------------------------------
'Italic' instance name is incorrect.

Families which have just one instance must name the single 'Regular'


================================================================================
FAIL: Check Win Ascent and Win Descent equal yMax, yMin of bbox
--------------------------------------------------------------------------------
Regular master's winDescent 303 is not equal to yMin 271

```


**Check single weight families have Regular style name**
Implementation of this check was wrong. Updated implementation will collect all the instances then check there's only 1 instance. That instance should be Regular.


**Check Win Ascent and Win Descent equal yMax, yMin of bbox**
Implementation now matches Fontbakery's, https://github.com/googlefonts/fontbakery/issues/1655. Previously, the win Ascent and Descent had to match the family's yMin and yMax.