### PR TITLE
Fixes for linkStyle and vert metric tests

### DIFF
--- a/Google Fonts/qa.py
+++ b/Google Fonts/qa.py
@@ -691,18 +691,16 @@ class TestVerticalMetrics(TestGlyphsFiles):
             for master in font.masters:
                 win_ascent = master.customParameters['winAscent']
                 win_descent = master.customParameters['winDescent']
-                self.assertEqual(
-                    int(win_ascent),
-                    ymax,
+                self.assertTrue(
+                    int(win_ascent) >= ymax,
                     ("%s master's winAscent %s is not equal to yMax %s") % (
                         master.name,
                         win_ascent,
                         ymax)
                 )
                 # ymin is abs because win descent is a positive integer
-                self.assertEqual(
-                    int(win_descent),
-                    abs(ymin),
+                self.assertTrue(
+                    int(win_descent) >= abs(ymin),
                     ("%s master's winDescent %s is not equal to yMin %s") % (
                         master.name,
                         win_descent,

--- a/Google Fonts/qa.py
+++ b/Google Fonts/qa.py
@@ -268,17 +268,19 @@ class TestFontInfo(TestGlyphsFiles):
 
         Single weight families which visually look heavy are not exempt
         from this rule."""
+        styles = []
         for font in self.fonts:
-            instances = font.instances
-            if len(instances) == 1:
-                instance = instances[0]
-                self.assertEqual(
-                    instance.name,
-                    'Regular',
-                    ("'%s' instance name is incorrect.\n\n"
-                     "Families which have just one instance must "
-                     "name the single 'Regular'") % instance.name
-                )
+            for instance in font.instances:
+                styles.append(instance.name)
+
+        if len(styles) == 1:
+            self.assertEqual(
+                styles[0],
+                'Regular',
+                ("'%s' instance name is incorrect.\n\n"
+                 "Families which have just one instance must "
+                 "name the instance 'Regular'") % styles[0]
+            )
 
     def test_italic_instances_have_isItalic_set(self):
         """Check only italic instances have 'isItalic' set"""

--- a/Google Fonts/qa.py
+++ b/Google Fonts/qa.py
@@ -340,8 +340,8 @@ class TestFontInfo(TestGlyphsFiles):
                 if 'Italic' in instance.name:
                     if instance.name == 'Italic' or instance.name == 'Bold Italic':
                         self.assertEqual(
-                            '',
-                            instance.linkStyle,
+                            len(instance.linkStyle),
+                            0,
                             ("%s instance must have no style linking.\n\n"
                              "Delete link to %s") % (
                                 instance.name,


### PR DESCRIPTION
- FIxed linkStyle issue reports in #37 
- Win asc and Win desc now match FB check. Value can be greater than or equal to bbox. Previously they had to be the same as yMax, yMin