### PR TITLE
Implement workaround for util.download_gf_family.

### DIFF
--- a/Google Fonts/utils.py
+++ b/Google Fonts/utils.py
@@ -55,7 +55,7 @@ def fonts_from_zip(zipfile):
     ttfs = []
     for file_name in zipfile.namelist():
         if 'ttf' in file_name:
-            ttfs.append(TTFont(zipfile.open(file_name)))
+            ttfs.append(TTFont(StringIO(zipfile.read(file_name))))
     return ttfs
 
 


### PR DESCRIPTION
Previous implementation would 'open' a font from a zipfile. Opened files from zipfile objects are unseekable streams. FontTools recently lost support to intantiate a TTFont object from such streams,
https://github.com/fonttools/fonttools/issues/1362

New implementation will 'read' the font from a zipfile which returns the bytes of the read file. The bytes are then stored as a StringIO object which is a seekable stream.