### PR TITLE
Set Encoding

### DIFF
--- a/Google Fonts/initial_vertmetrics.py
+++ b/Google Fonts/initial_vertmetrics.py
@@ -1,4 +1,5 @@
 #MenuTitle: Initial setting of vertical metrics
+# -*- coding: utf-8 -*-
 '''
 
 Calculates vertical metrics according to https://github.com/googlefonts/fontbakery/issues/2164#issuecomment-436595886, sets them in all masters, deletes them in all instances.


### PR DESCRIPTION
```
Start
  File "~/Library/Application Support/Glyphs/Scripts/gf-glyphs-scripts-master/initial_vertmetrics.py", line 15
SyntaxError: Non-ASCII character '\xe2' in file ~/Library/Application Support/Glyphs/Scripts/gf-glyphs-scripts-master/initial_vertmetrics.py on line 15, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
End
```
Fix this error